### PR TITLE
feat(protocol): derive daily snapshots for total owed $M

### DIFF
--- a/protocol/generated/schema.ts
+++ b/protocol/generated/schema.ts
@@ -1986,8 +1986,8 @@ export class TotalActiveOwedMDailySnapshot extends Entity {
     this.set("blockTimestamp", Value.fromBigInt(value));
   }
 
-  get dayTimestamp(): BigInt {
-    let value = this.get("dayTimestamp");
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
@@ -1995,8 +1995,8 @@ export class TotalActiveOwedMDailySnapshot extends Entity {
     }
   }
 
-  set dayTimestamp(value: BigInt) {
-    this.set("dayTimestamp", Value.fromBigInt(value));
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
   }
 }
 

--- a/protocol/generated/schema.ts
+++ b/protocol/generated/schema.ts
@@ -1897,6 +1897,96 @@ export class TotalActiveOwedM extends Entity {
   }
 }
 
+export class TotalActiveOwedMDailySnapshot extends Entity {
+  constructor(id: Bytes) {
+    super();
+    this.set("id", Value.fromBytes(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(
+      id != null,
+      "Cannot save TotalActiveOwedMDailySnapshot entity without an ID",
+    );
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type TotalActiveOwedMDailySnapshot must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+      );
+      store.set(
+        "TotalActiveOwedMDailySnapshot",
+        id.toBytes().toHexString(),
+        this,
+      );
+    }
+  }
+
+  static loadInBlock(id: Bytes): TotalActiveOwedMDailySnapshot | null {
+    return changetype<TotalActiveOwedMDailySnapshot | null>(
+      store.get_in_block("TotalActiveOwedMDailySnapshot", id.toHexString()),
+    );
+  }
+
+  static load(id: Bytes): TotalActiveOwedMDailySnapshot | null {
+    return changetype<TotalActiveOwedMDailySnapshot | null>(
+      store.get("TotalActiveOwedMDailySnapshot", id.toHexString()),
+    );
+  }
+
+  get id(): Bytes {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
+  }
+
+  get amount(): BigInt {
+    let value = this.get("amount");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set amount(value: BigInt) {
+    this.set("amount", Value.fromBigInt(value));
+  }
+
+  get blockNumber(): BigInt {
+    let value = this.get("blockNumber");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
+  }
+
+  get blockTimestamp(): BigInt {
+    let value = this.get("blockTimestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
+  }
+}
+
 export class TotalInactiveOwedM extends Entity {
   constructor(id: Bytes) {
     super();

--- a/protocol/generated/schema.ts
+++ b/protocol/generated/schema.ts
@@ -1985,6 +1985,19 @@ export class TotalActiveOwedMDailySnapshot extends Entity {
   set blockTimestamp(value: BigInt) {
     this.set("blockTimestamp", Value.fromBigInt(value));
   }
+
+  get dayTimestamp(): BigInt {
+    let value = this.get("dayTimestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set dayTimestamp(value: BigInt) {
+    this.set("dayTimestamp", Value.fromBigInt(value));
+  }
 }
 
 export class TotalInactiveOwedM extends Entity {

--- a/protocol/generated/schema.ts
+++ b/protocol/generated/schema.ts
@@ -1898,9 +1898,9 @@ export class TotalActiveOwedM extends Entity {
 }
 
 export class TotalActiveOwedMDailySnapshot extends Entity {
-  constructor(id: Bytes) {
+  constructor(id: string) {
     super();
-    this.set("id", Value.fromBytes(id));
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
@@ -1911,40 +1911,36 @@ export class TotalActiveOwedMDailySnapshot extends Entity {
     );
     if (id) {
       assert(
-        id.kind == ValueKind.BYTES,
-        `Entities of type TotalActiveOwedMDailySnapshot must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.STRING,
+        `Entities of type TotalActiveOwedMDailySnapshot must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set(
-        "TotalActiveOwedMDailySnapshot",
-        id.toBytes().toHexString(),
-        this,
-      );
+      store.set("TotalActiveOwedMDailySnapshot", id.toString(), this);
     }
   }
 
-  static loadInBlock(id: Bytes): TotalActiveOwedMDailySnapshot | null {
+  static loadInBlock(id: string): TotalActiveOwedMDailySnapshot | null {
     return changetype<TotalActiveOwedMDailySnapshot | null>(
-      store.get_in_block("TotalActiveOwedMDailySnapshot", id.toHexString()),
+      store.get_in_block("TotalActiveOwedMDailySnapshot", id),
     );
   }
 
-  static load(id: Bytes): TotalActiveOwedMDailySnapshot | null {
+  static load(id: string): TotalActiveOwedMDailySnapshot | null {
     return changetype<TotalActiveOwedMDailySnapshot | null>(
-      store.get("TotalActiveOwedMDailySnapshot", id.toHexString()),
+      store.get("TotalActiveOwedMDailySnapshot", id),
     );
   }
 
-  get id(): Bytes {
+  get id(): string {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toBytes();
+      return value.toString();
     }
   }
 
-  set id(value: Bytes) {
-    this.set("id", Value.fromBytes(value));
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
   }
 
   get amount(): BigInt {

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -1,5 +1,6 @@
 {
   "name": "protocol",
+  "version": "1.1.0",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "graph codegen",

--- a/protocol/schema.graphql
+++ b/protocol/schema.graphql
@@ -156,7 +156,7 @@ type TotalActiveOwedM @entity(immutable: true) {
   blockTimestamp: BigInt!
 }
 
-type TotalActiveOwedMDailySnapshot @entity(immutable: true) {
+type TotalActiveOwedMDailySnapshot @entity(immutable: false) {
   id: String!
   amount: BigInt!
   blockNumber: BigInt!

--- a/protocol/schema.graphql
+++ b/protocol/schema.graphql
@@ -161,6 +161,7 @@ type TotalActiveOwedMDailySnapshot @entity(immutable: true) {
   amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
+  dayTimestamp: BigInt!
 }
 
 type TotalInactiveOwedM @entity(immutable: true) {

--- a/protocol/schema.graphql
+++ b/protocol/schema.graphql
@@ -161,7 +161,7 @@ type TotalActiveOwedMDailySnapshot @entity(immutable: true) {
   amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
-  dayTimestamp: BigInt!
+  timestamp: BigInt!
 }
 
 type TotalInactiveOwedM @entity(immutable: true) {

--- a/protocol/schema.graphql
+++ b/protocol/schema.graphql
@@ -1,6 +1,6 @@
-# 
+#
 # MinterGateway events
-# 
+#
 type BurnExecuted @entity(immutable: true) {
   id: Bytes!
   minter: Bytes! # address
@@ -132,33 +132,40 @@ type UndercollateralizedPenaltyImposed @entity(immutable: true) {
   blockTimestamp: BigInt!
   transactionHash: Bytes!
 }
-# 
+#
 # MinterGateway - NON events entities - timeseries - updated by handleNewBlock
-# 
+#
 type PrincipalOfTotalActiveOwedM @entity(immutable: true) {
   id: Bytes!
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
 type TotalOwedM @entity(immutable: true) {
   id: Bytes!
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
 type TotalActiveOwedM @entity(immutable: true) {
   id: Bytes!
-  amount: BigInt! 
+  amount: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+}
+
+type TotalActiveOwedMDailySnapshot @entity(immutable: true) {
+  id: Bytes!
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
 type TotalInactiveOwedM @entity(immutable: true) {
   id: Bytes!
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
@@ -166,47 +173,47 @@ type TotalInactiveOwedM @entity(immutable: true) {
 # The difference between total owed M and M token total supply.
 type TotalExcessOwedM @entity(immutable: true) {
   id: Bytes!
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
-# 
+#
 # Minter Entitites
-# 
-type MinterActiveOwedMOf @entity(immutable: true){
+#
+type MinterActiveOwedMOf @entity(immutable: true) {
   id: String!
   minter: Bytes! # address
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
-type MinterInactiveOwedMOf @entity(immutable: true){
+type MinterInactiveOwedMOf @entity(immutable: true) {
   id: String!
   minter: Bytes! # address
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
-type MinterPrincipalOfActiveOwedMOf @entity(immutable: true){
+type MinterPrincipalOfActiveOwedMOf @entity(immutable: true) {
   id: String!
   minter: Bytes! # address
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
 
-type MinterCollateralOf @entity(immutable: true){
+type MinterCollateralOf @entity(immutable: true) {
   id: String!
   minter: Bytes! # address
-  amount: BigInt! 
+  amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
-# 
+#
 # M token special events
-# 
+#
 type MTokenAuthorizationCanceled @entity(immutable: true) {
   id: Bytes!
   authorizer: Bytes! # address

--- a/protocol/schema.graphql
+++ b/protocol/schema.graphql
@@ -157,7 +157,7 @@ type TotalActiveOwedM @entity(immutable: true) {
 }
 
 type TotalActiveOwedMDailySnapshot @entity(immutable: true) {
-  id: Bytes!
+  id: String!
   amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -320,22 +320,16 @@ function createTotalActiveOwedMDailySnapshot(
   let day = dayFromTimestamp(block.timestamp);
   const id = day.toString();
 
-  let existing = TotalActiveOwedMDailySnapshot.load(id);
+  // Update or create the TotalActiveOwedMDailySnapshot entity
+  const existing = TotalActiveOwedMDailySnapshot.load(id);
+  const entity: TotalActiveOwedMDailySnapshot =
+    existing == null ? new TotalActiveOwedMDailySnapshot(id) : existing;
 
-  if (existing == null) {
-    let entity = new TotalActiveOwedMDailySnapshot(id);
-    entity.amount = amount;
-    entity.blockNumber = block.number;
-    entity.blockTimestamp = block.timestamp;
-    entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
-    entity.save();
-  } else {
-    existing.amount = amount;
-    existing.blockNumber = block.number;
-    existing.blockTimestamp = block.timestamp;
-    existing.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
-    existing.save();
-  }
+  entity.amount = amount;
+  entity.blockNumber = block.number;
+  entity.blockTimestamp = block.timestamp;
+  entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+  entity.save();
 }
 
 export function handleTotalInactiveOwedM(block: ethereum.Block): void {

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -1,10 +1,4 @@
-import {
-  ethereum,
-  Address,
-  BigInt,
-  dataSource,
-  Entity,
-} from "@graphprotocol/graph-ts";
+import { ethereum, Address, BigInt, dataSource } from "@graphprotocol/graph-ts";
 
 import {
   BurnExecuted as BurnExecutedEvent,
@@ -22,7 +16,7 @@ import {
   RetrievalResolved as RetrievalResolvedEvent,
   UndercollateralizedPenaltyImposed as UndercollateralizedPenaltyImposedEvent,
   MinterGateway as MinterGatewayContract,
-} from "../generated/MinterGateway/MinterGateway"
+} from "../generated/MinterGateway/MinterGateway";
 import {
   BurnExecuted,
   CollateralUpdated,
@@ -40,45 +34,50 @@ import {
   PrincipalOfTotalActiveOwedM,
   TotalOwedM,
   TotalActiveOwedM,
+  TotalActiveOwedMDailySnapshot,
   TotalInactiveOwedM,
   TotalExcessOwedM,
   MinterActiveOwedMOf,
   MinterInactiveOwedMOf,
   MinterPrincipalOfActiveOwedMOf,
   MinterCollateralOf,
-} from "../generated/schema"
+} from "../generated/schema";
+
+import { dayFromTimestamp } from "./utils";
 
 export function handleBurnExecutedActiveOwedM(event: BurnExecutedEvent): void {
   let entity = new BurnExecuted(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.amount = event.params.amount
-  entity.payer = event.params.payer
+  );
+  entity.minter = event.params.minter;
+  entity.amount = event.params.amount;
+  entity.payer = event.params.payer;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<BurnExecutedEvent>(event);
 }
 
-export function handleBurnExecutedInactiveOwedM(event: BurnExecuted1Event): void {
+export function handleBurnExecutedInactiveOwedM(
+  event: BurnExecuted1Event
+): void {
   let entity = new BurnExecuted(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.amount = event.params.amount
-  entity.payer = event.params.payer
-  entity.principalAmount = event.params.principalAmount
+  );
+  entity.minter = event.params.minter;
+  entity.amount = event.params.amount;
+  entity.payer = event.params.payer;
+  entity.principalAmount = event.params.principalAmount;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<BurnExecuted1Event>(event);
 }
@@ -86,19 +85,19 @@ export function handleBurnExecutedInactiveOwedM(event: BurnExecuted1Event): void
 export function handleCollateralUpdated(event: CollateralUpdatedEvent): void {
   let entity = new CollateralUpdated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.collateral = event.params.collateral
+  );
+  entity.minter = event.params.minter;
+  entity.collateral = event.params.collateral;
   entity.totalResolvedCollateralRetrieval =
-    event.params.totalResolvedCollateralRetrieval
-  entity.metadataHash = event.params.metadataHash
-  entity.timestamp = event.params.timestamp
+    event.params.totalResolvedCollateralRetrieval;
+  entity.metadataHash = event.params.metadataHash;
+  entity.timestamp = event.params.timestamp;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<CollateralUpdatedEvent>(event);
 }
@@ -106,30 +105,30 @@ export function handleCollateralUpdated(event: CollateralUpdatedEvent): void {
 export function handleIndexUpdated(event: IndexUpdatedEvent): void {
   let entity = new IndexUpdated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.index = event.params.index
-  entity.rate = event.params.rate
+  );
+  entity.index = event.params.index;
+  entity.rate = event.params.rate;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 }
 
 export function handleMintCanceled(event: MintCanceledEvent): void {
   let entity = new MintCanceled(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.mintId = event.params.mintId
-  entity.minter = event.params.minter
-  entity.canceller = event.params.canceller
+  );
+  entity.mintId = event.params.mintId;
+  entity.minter = event.params.minter;
+  entity.canceller = event.params.canceller;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<MintCanceledEvent>(event);
 }
@@ -137,16 +136,16 @@ export function handleMintCanceled(event: MintCanceledEvent): void {
 export function handleMintExecuted(event: MintExecutedEvent): void {
   let entity = new MintExecuted(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.mintId = event.params.mintId
-  entity.minter = event.params.minter
-  entity.principalAmount = event.params.principalAmount
-  entity.amount = event.params.amount
+  );
+  entity.mintId = event.params.mintId;
+  entity.minter = event.params.minter;
+  entity.principalAmount = event.params.principalAmount;
+  entity.amount = event.params.amount;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
-  entity.save()
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
+  entity.save();
 
   handleMinterAttributes<MintExecutedEvent>(event);
 }
@@ -154,31 +153,31 @@ export function handleMintExecuted(event: MintExecutedEvent): void {
 export function handleMintProposed(event: MintProposedEvent): void {
   let entity = new MintProposed(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.mintId = event.params.mintId
-  entity.minter = event.params.minter
-  entity.amount = event.params.amount
-  entity.destination = event.params.destination
+  );
+  entity.mintId = event.params.mintId;
+  entity.minter = event.params.minter;
+  entity.amount = event.params.amount;
+  entity.destination = event.params.destination;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 }
 
 export function handleMinterActivated(event: MinterActivatedEvent): void {
   let entity = new MinterActivated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.caller = event.params.caller
+  );
+  entity.minter = event.params.minter;
+  entity.caller = event.params.caller;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<MinterActivatedEvent>(event);
 }
@@ -186,16 +185,16 @@ export function handleMinterActivated(event: MinterActivatedEvent): void {
 export function handleMinterDeactivated(event: MinterDeactivatedEvent): void {
   let entity = new MinterDeactivated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.inactiveOwedM = event.params.inactiveOwedM
-  entity.caller = event.params.caller
+  );
+  entity.minter = event.params.minter;
+  entity.inactiveOwedM = event.params.inactiveOwedM;
+  entity.caller = event.params.caller;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<MinterDeactivatedEvent>(event);
 }
@@ -203,15 +202,15 @@ export function handleMinterDeactivated(event: MinterDeactivatedEvent): void {
 export function handleMinterFrozen(event: MinterFrozenEvent): void {
   let entity = new MinterFrozen(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.frozenUntil = event.params.frozenUntil
+  );
+  entity.minter = event.params.minter;
+  entity.frozenUntil = event.params.frozenUntil;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<MinterFrozenEvent>(event);
 }
@@ -221,16 +220,16 @@ export function handleMissedIntervalsPenaltyImposed(
 ): void {
   let entity = new MissedIntervalsPenaltyImposed(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.missedIntervals = event.params.missedIntervals
-  entity.penaltyAmount = event.params.penaltyAmount
+  );
+  entity.minter = event.params.minter;
+  entity.missedIntervals = event.params.missedIntervals;
+  entity.penaltyAmount = event.params.penaltyAmount;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<MissedIntervalsPenaltyImposedEvent>(event);
 }
@@ -238,16 +237,16 @@ export function handleMissedIntervalsPenaltyImposed(
 export function handleRetrievalCreated(event: RetrievalCreatedEvent): void {
   let entity = new RetrievalCreated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.retrievalId = event.params.retrievalId
-  entity.minter = event.params.minter
-  entity.amount = event.params.amount
+  );
+  entity.retrievalId = event.params.retrievalId;
+  entity.minter = event.params.minter;
+  entity.amount = event.params.amount;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<RetrievalCreatedEvent>(event);
 }
@@ -255,15 +254,15 @@ export function handleRetrievalCreated(event: RetrievalCreatedEvent): void {
 export function handleRetrievalResolved(event: RetrievalResolvedEvent): void {
   let entity = new RetrievalResolved(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.retrievalId = event.params.retrievalId
-  entity.minter = event.params.minter
+  );
+  entity.retrievalId = event.params.retrievalId;
+  entity.minter = event.params.minter;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<RetrievalResolvedEvent>(event);
 }
@@ -273,17 +272,17 @@ export function handleUndercollateralizedPenaltyImposed(
 ): void {
   let entity = new UndercollateralizedPenaltyImposed(
     event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-  entity.minter = event.params.minter
-  entity.excessOwedM = event.params.excessOwedM
-  entity.timeSpan = event.params.timeSpan
-  entity.penaltyAmount = event.params.penaltyAmount
+  );
+  entity.minter = event.params.minter;
+  entity.excessOwedM = event.params.excessOwedM;
+  entity.timeSpan = event.params.timeSpan;
+  entity.penaltyAmount = event.params.penaltyAmount;
 
-  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
+  entity.blockNumber = event.block.number;
+  entity.blockTimestamp = event.block.timestamp;
+  entity.transactionHash = event.transaction.hash;
 
-  entity.save()
+  entity.save();
 
   handleMinterAttributes<UndercollateralizedPenaltyImposedEvent>(event);
 }
@@ -292,48 +291,70 @@ export function handleUndercollateralizedPenaltyImposed(
 //
 export function handlePrincipalOfTotalActiveOwedM(block: ethereum.Block): void {
   // Bind the contract to the address that emitted the event
-  let contract = MinterGatewayContract.bind(dataSource.address())
-  let amount = contract.principalOfTotalActiveOwedM()
-  let entity = new PrincipalOfTotalActiveOwedM(block.hash)
-  createTimeseriesEntity<PrincipalOfTotalActiveOwedM>(entity, amount, block)
+  let contract = MinterGatewayContract.bind(dataSource.address());
+  let amount = contract.principalOfTotalActiveOwedM();
+  let entity = new PrincipalOfTotalActiveOwedM(block.hash);
+  createTimeseriesEntity<PrincipalOfTotalActiveOwedM>(entity, amount, block);
 }
 
 export function handleTotalOwedM(block: ethereum.Block): void {
-  let contract = MinterGatewayContract.bind(dataSource.address())
-  let amount = contract.totalOwedM()
-  let entity = new TotalOwedM(block.hash)
-  createTimeseriesEntity<TotalOwedM>(entity, amount, block)
+  let contract = MinterGatewayContract.bind(dataSource.address());
+  let amount = contract.totalOwedM();
+  let entity = new TotalOwedM(block.hash);
+  createTimeseriesEntity<TotalOwedM>(entity, amount, block);
 }
 
 export function handleTotalActiveOwedM(block: ethereum.Block): void {
-  let contract = MinterGatewayContract.bind(dataSource.address())
-  let amount = contract.totalActiveOwedM()
-  let entity = new TotalActiveOwedM(block.hash)
-  createTimeseriesEntity<TotalActiveOwedM>(entity, amount, block)
+  let contract = MinterGatewayContract.bind(dataSource.address());
+  let amount = contract.totalActiveOwedM();
+  let entity = new TotalActiveOwedM(block.hash);
+  entity = createTimeseriesEntity<TotalActiveOwedM>(entity, amount, block);
+
+  createTotalActiveOwedMDailySnapshot(entity);
+}
+
+function createTotalActiveOwedMDailySnapshot(owedM: TotalActiveOwedM): void {
+  let day = dayFromTimestamp(owedM.blockTimestamp);
+  let existing = TotalActiveOwedMDailySnapshot.load(owedM.id);
+
+  if (existing == null) {
+    let entity = new TotalActiveOwedMDailySnapshot(owedM.id);
+    entity.amount = owedM.amount;
+    entity.blockNumber = owedM.blockNumber;
+    entity.blockTimestamp = owedM.blockTimestamp;
+    entity.dayTimestamp = day;
+    entity.save();
+  }
 }
 
 export function handleTotalInactiveOwedM(block: ethereum.Block): void {
   // Bind the contract to the address that emitted the event
-  let contract = MinterGatewayContract.bind(dataSource.address())
-  let amount = contract.totalInactiveOwedM()
-  let entity = new TotalInactiveOwedM(block.hash)
-  createTimeseriesEntity<TotalInactiveOwedM>(entity, amount, block)
+  let contract = MinterGatewayContract.bind(dataSource.address());
+  let amount = contract.totalInactiveOwedM();
+  let entity = new TotalInactiveOwedM(block.hash);
+  createTimeseriesEntity<TotalInactiveOwedM>(entity, amount, block);
 }
 
 export function handleTotalExcessOwedM(block: ethereum.Block): void {
-  let contract = MinterGatewayContract.bind(dataSource.address())
-  let amount = contract.excessOwedM()
-  let entity = new TotalExcessOwedM(block.hash)
-  createTimeseriesEntity<TotalExcessOwedM>(entity, amount, block)
+  let contract = MinterGatewayContract.bind(dataSource.address());
+  let amount = contract.excessOwedM();
+  let entity = new TotalExcessOwedM(block.hash);
+  createTimeseriesEntity<TotalExcessOwedM>(entity, amount, block);
 }
 
-function createTimeseriesEntity<E extends TotalOwedM>(entity: E, amount: BigInt, block: ethereum.Block): void{
-  if(amount && amount.gt(BigInt.fromI32(0))) {
-    entity.amount = amount
-    entity.blockNumber = block.number
-    entity.blockTimestamp = block.timestamp
-    entity.save()
+function createTimeseriesEntity<E extends TotalOwedM>(
+  entity: E,
+  amount: BigInt,
+  block: ethereum.Block
+): E {
+  if (amount && amount.gt(BigInt.fromI32(0))) {
+    entity.amount = amount;
+    entity.blockNumber = block.number;
+    entity.blockTimestamp = block.timestamp;
+    entity.save();
   }
+
+  return entity;
 }
 
 export function handleNewBlock(block: ethereum.Block): void {
@@ -343,9 +364,9 @@ export function handleNewBlock(block: ethereum.Block): void {
   handleTotalInactiveOwedM(block);
   handleTotalExcessOwedM(block);
 }
-// 
+//
 // Minter entities
-// 
+//
 export class HasMinterParams {
   _event: HasMinterEvent;
 
@@ -363,7 +384,9 @@ export class HasMinterEvent extends ethereum.Event {
   }
 }
 
-export function handleMinterAttributes<T extends HasMinterEvent>(event: T):void{
+export function handleMinterAttributes<T extends HasMinterEvent>(
+  event: T
+): void {
   handleNewBlock(event.block);
   handleMinterActiveOwedMOf<T>(event);
   handleMinterInactiveOwedMOf<T>(event);
@@ -371,49 +394,76 @@ export function handleMinterAttributes<T extends HasMinterEvent>(event: T):void{
   handleMinterCollateralOf<T>(event);
 }
 
-export function handleMinterActiveOwedMOf<T extends HasMinterEvent>(event: T): void {
-  let contract = MinterGatewayContract.bind(event.address)
-  let amount = contract.activeOwedMOf(event.params.minter)
+export function handleMinterActiveOwedMOf<T extends HasMinterEvent>(
+  event: T
+): void {
+  let contract = MinterGatewayContract.bind(event.address);
+  let amount = contract.activeOwedMOf(event.params.minter);
   let entity = new MinterActiveOwedMOf(
-    event.params.minter.toString().concat("-").concat(event.block.number.toString())
-  )
-  createMinterAttributeEntity<MinterActiveOwedMOf, T>(entity, amount, event)
+    event.params.minter
+      .toString()
+      .concat("-")
+      .concat(event.block.number.toString())
+  );
+  createMinterAttributeEntity<MinterActiveOwedMOf, T>(entity, amount, event);
 }
 
-export function handleMinterInactiveOwedMOf<T extends HasMinterEvent>(event: T): void {
-  let contract = MinterGatewayContract.bind(event.address)
-  let amount = contract.inactiveOwedMOf(event.params.minter)
+export function handleMinterInactiveOwedMOf<T extends HasMinterEvent>(
+  event: T
+): void {
+  let contract = MinterGatewayContract.bind(event.address);
+  let amount = contract.inactiveOwedMOf(event.params.minter);
   let entity = new MinterInactiveOwedMOf(
-    event.params.minter.toString().concat("-").concat(event.block.number.toString())
-  )
-  createMinterAttributeEntity<MinterInactiveOwedMOf, T>(entity, amount, event)
+    event.params.minter
+      .toString()
+      .concat("-")
+      .concat(event.block.number.toString())
+  );
+  createMinterAttributeEntity<MinterInactiveOwedMOf, T>(entity, amount, event);
 }
 
-export function handleMinterPrincipalOfActiveOwedMOf<T extends HasMinterEvent>(event: T): void {
-  let contract = MinterGatewayContract.bind(event.address)
-  let amount = contract.principalOfActiveOwedMOf(event.params.minter)
+export function handleMinterPrincipalOfActiveOwedMOf<T extends HasMinterEvent>(
+  event: T
+): void {
+  let contract = MinterGatewayContract.bind(event.address);
+  let amount = contract.principalOfActiveOwedMOf(event.params.minter);
   let entity = new MinterPrincipalOfActiveOwedMOf(
-    event.params.minter.toString().concat("-").concat(event.block.number.toString())
-  )
-  createMinterAttributeEntity<MinterPrincipalOfActiveOwedMOf, T>(entity, amount, event)
+    event.params.minter
+      .toString()
+      .concat("-")
+      .concat(event.block.number.toString())
+  );
+  createMinterAttributeEntity<MinterPrincipalOfActiveOwedMOf, T>(
+    entity,
+    amount,
+    event
+  );
 }
 
-export function handleMinterCollateralOf<T extends HasMinterEvent>(event: T): void {
-  let contract = MinterGatewayContract.bind(event.address)
-  let amount = contract.collateralOf(event.params.minter)
+export function handleMinterCollateralOf<T extends HasMinterEvent>(
+  event: T
+): void {
+  let contract = MinterGatewayContract.bind(event.address);
+  let amount = contract.collateralOf(event.params.minter);
   let entity = new MinterCollateralOf(
-    event.params.minter.toString().concat("-").concat(event.block.number.toString())
-  )
-  createMinterAttributeEntity<MinterCollateralOf, T>(entity, amount, event)
+    event.params.minter
+      .toString()
+      .concat("-")
+      .concat(event.block.number.toString())
+  );
+  createMinterAttributeEntity<MinterCollateralOf, T>(entity, amount, event);
 }
 // assemblescript does not support union type then can be achieved by using generic type
 // https://www.assemblyscript.org/concepts.html
-function createMinterAttributeEntity<E extends MinterActiveOwedMOf, T extends HasMinterEvent>(entity: E, amount: BigInt, event: T):void {
-  if(amount) {
-    entity.amount = amount
-    entity.minter = event.params.minter
-    entity.blockNumber = event.block.number
-    entity.blockTimestamp = event.block.timestamp
-    entity.save()
+function createMinterAttributeEntity<
+  E extends MinterActiveOwedMOf,
+  T extends HasMinterEvent,
+>(entity: E, amount: BigInt, event: T): void {
+  if (amount) {
+    entity.amount = amount;
+    entity.minter = event.params.minter;
+    entity.blockNumber = event.block.number;
+    entity.blockTimestamp = event.block.timestamp;
+    entity.save();
   }
 }

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -43,7 +43,7 @@ import {
   MinterCollateralOf,
 } from "../generated/schema";
 
-import { dayFromTimestamp } from "./utils";
+import { dayFromTimestamp, SECONDS_PER_DAY } from "./utils";
 
 export function handleBurnExecutedActiveOwedM(event: BurnExecutedEvent): void {
   let entity = new BurnExecuted(
@@ -322,7 +322,7 @@ function createTotalActiveOwedMDailySnapshot(owedM: TotalActiveOwedM): void {
     entity.amount = owedM.amount;
     entity.blockNumber = owedM.blockNumber;
     entity.blockTimestamp = owedM.blockTimestamp;
-    entity.dayTimestamp = day;
+    entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
     entity.save();
   }
 }

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -308,22 +308,25 @@ export function handleTotalActiveOwedM(block: ethereum.Block): void {
   let contract = MinterGatewayContract.bind(dataSource.address());
   let amount = contract.totalActiveOwedM();
   let entity = new TotalActiveOwedM(block.hash);
-  entity = createTimeseriesEntity<TotalActiveOwedM>(entity, amount, block);
+  createTimeseriesEntity<TotalActiveOwedM>(entity, amount, block);
 
-  createTotalActiveOwedMDailySnapshot(entity);
+  createTotalActiveOwedMDailySnapshot(amount, block);
 }
 
-function createTotalActiveOwedMDailySnapshot(owedM: TotalActiveOwedM): void {
-  let day = dayFromTimestamp(owedM.blockTimestamp);
+function createTotalActiveOwedMDailySnapshot(
+  amount: BigInt,
+  block: ethereum.Block
+): void {
+  let day = dayFromTimestamp(block.timestamp);
   const id = day.toString();
 
   let existing = TotalActiveOwedMDailySnapshot.load(id);
 
   if (existing == null) {
     let entity = new TotalActiveOwedMDailySnapshot(id);
-    entity.amount = owedM.amount;
-    entity.blockNumber = owedM.blockNumber;
-    entity.blockTimestamp = owedM.blockTimestamp;
+    entity.amount = amount;
+    entity.blockNumber = block.number;
+    entity.blockTimestamp = block.timestamp;
     entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
     entity.save();
   }

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -315,10 +315,12 @@ export function handleTotalActiveOwedM(block: ethereum.Block): void {
 
 function createTotalActiveOwedMDailySnapshot(owedM: TotalActiveOwedM): void {
   let day = dayFromTimestamp(owedM.blockTimestamp);
-  let existing = TotalActiveOwedMDailySnapshot.load(owedM.id);
+  const id = day.toString();
+
+  let existing = TotalActiveOwedMDailySnapshot.load(id);
 
   if (existing == null) {
-    let entity = new TotalActiveOwedMDailySnapshot(owedM.id);
+    let entity = new TotalActiveOwedMDailySnapshot(id);
     entity.amount = owedM.amount;
     entity.blockNumber = owedM.blockNumber;
     entity.blockTimestamp = owedM.blockTimestamp;

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -320,16 +320,22 @@ function createTotalActiveOwedMDailySnapshot(
   let day = dayFromTimestamp(block.timestamp);
   const id = day.toString();
 
-  // Update or create the TotalActiveOwedMDailySnapshot entity
-  const existing = TotalActiveOwedMDailySnapshot.load(id);
-  const entity: TotalActiveOwedMDailySnapshot =
-    existing == null ? new TotalActiveOwedMDailySnapshot(id) : existing;
+  let existing = TotalActiveOwedMDailySnapshot.load(id);
 
-  entity.amount = amount;
-  entity.blockNumber = block.number;
-  entity.blockTimestamp = block.timestamp;
-  entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
-  entity.save();
+  if (existing == null) {
+    let entity = new TotalActiveOwedMDailySnapshot(id);
+    entity.amount = amount;
+    entity.blockNumber = block.number;
+    entity.blockTimestamp = block.timestamp;
+    entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+    entity.save();
+  } else {
+    existing.amount = amount;
+    existing.blockNumber = block.number;
+    existing.blockTimestamp = block.timestamp;
+    existing.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+    existing.save();
+  }
 }
 
 export function handleTotalInactiveOwedM(block: ethereum.Block): void {

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -320,23 +320,16 @@ function createTotalActiveOwedMDailySnapshot(
   let day = dayFromTimestamp(block.timestamp);
   const id = day.toString();
 
-  let existing = TotalActiveOwedMDailySnapshot.load(id);
-  const timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+  // Update or create the TotalActiveOwedMDailySnapshot entity
+  const existing = TotalActiveOwedMDailySnapshot.load(id);
+  const entity: TotalActiveOwedMDailySnapshot =
+    existing == null ? new TotalActiveOwedMDailySnapshot(id) : existing;
 
-  if (existing == null) {
-    let entity = new TotalActiveOwedMDailySnapshot(id);
-    entity.amount = amount;
-    entity.blockNumber = block.number;
-    entity.blockTimestamp = block.timestamp;
-    entity.timestamp = timestamp;
-    entity.save();
-  } else {
-    existing.amount = amount;
-    existing.blockNumber = block.number;
-    existing.blockTimestamp = block.timestamp;
-    existing.timestamp = timestamp;
-    existing.save();
-  }
+  entity.amount = amount;
+  entity.blockNumber = block.number;
+  entity.blockTimestamp = block.timestamp;
+  entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+  entity.save();
 }
 
 export function handleTotalInactiveOwedM(block: ethereum.Block): void {

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -321,19 +321,20 @@ function createTotalActiveOwedMDailySnapshot(
   const id = day.toString();
 
   let existing = TotalActiveOwedMDailySnapshot.load(id);
+  const timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
 
   if (existing == null) {
     let entity = new TotalActiveOwedMDailySnapshot(id);
     entity.amount = amount;
     entity.blockNumber = block.number;
     entity.blockTimestamp = block.timestamp;
-    entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+    entity.timestamp = timestamp;
     entity.save();
   } else {
     existing.amount = amount;
     existing.blockNumber = block.number;
     existing.blockTimestamp = block.timestamp;
-    existing.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+    existing.timestamp = timestamp;
     existing.save();
   }
 }

--- a/protocol/src/minter-gateway.ts
+++ b/protocol/src/minter-gateway.ts
@@ -329,6 +329,12 @@ function createTotalActiveOwedMDailySnapshot(
     entity.blockTimestamp = block.timestamp;
     entity.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
     entity.save();
+  } else {
+    existing.amount = amount;
+    existing.blockNumber = block.number;
+    existing.blockTimestamp = block.timestamp;
+    existing.timestamp = day.times(SECONDS_PER_DAY); // Convert day to timestamp
+    existing.save();
   }
 }
 

--- a/protocol/src/utils.ts
+++ b/protocol/src/utils.ts
@@ -1,0 +1,11 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+/**
+ * Get the unique day number from a timestamp.
+ */
+export function dayFromTimestamp(timestamp: BigInt): BigInt {
+  let secondsInDay = 86400;
+  let dayNumber = timestamp.toI32() / secondsInDay;
+
+  return BigInt.fromI32(dayNumber);
+}

--- a/protocol/src/utils.ts
+++ b/protocol/src/utils.ts
@@ -1,11 +1,12 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 
+export const SECONDS_PER_DAY = BigInt.fromI32(86400);
+
 /**
  * Get the unique day number from a timestamp.
  */
 export function dayFromTimestamp(timestamp: BigInt): BigInt {
-  let secondsInDay = 86400;
-  let dayNumber = timestamp.toI32() / secondsInDay;
+  let dayNumber = timestamp.div(SECONDS_PER_DAY);
 
-  return BigInt.fromI32(dayNumber);
+  return dayNumber;
 }

--- a/protocol/yarn.lock
+++ b/protocol/yarn.lock
@@ -253,17 +253,17 @@
     which "2.0.2"
     yaml "1.10.2"
 
-"@graphprotocol/graph-ts@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.27.0.tgz"
-  integrity sha512-r1SPDIZVQiGMxcY8rhFSM0y7d/xAbQf5vHMWUf59js1KgoyWpM6P3tczZqmQd7JTmeyNsDGIPzd9FeaxllsU4w==
-  dependencies:
-    assemblyscript "0.19.10"
-
 "@graphprotocol/graph-ts@0.32.0":
   version "0.32.0"
   resolved "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.32.0.tgz"
   integrity sha512-YfKLT2w+ItXD/VPYQiAKtINQONVsAOkcqVFMHlhUy0fcEBVWuFBT53hJNI0/l5ujQa4TSxtzrKW/7EABAdgI8g==
+  dependencies:
+    assemblyscript "0.19.10"
+
+"@graphprotocol/graph-ts@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.27.0.tgz"
+  integrity sha512-r1SPDIZVQiGMxcY8rhFSM0y7d/xAbQf5vHMWUf59js1KgoyWpM6P3tczZqmQd7JTmeyNsDGIPzd9FeaxllsU4w==
   dependencies:
     assemblyscript "0.19.10"
 
@@ -321,7 +321,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -333,40 +333,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
-
-"@oclif/core@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-2.16.0.tgz"
-  integrity sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==
-  dependencies:
-    "@types/cli-progress" "^3.11.0"
-    ansi-escapes "^4.3.2"
-    ansi-styles "^4.3.0"
-    cardinal "^2.1.1"
-    chalk "^4.1.2"
-    clean-stack "^3.0.1"
-    cli-progress "^3.12.0"
-    debug "^4.3.4"
-    ejs "^3.1.8"
-    get-package-type "^0.1.0"
-    globby "^11.1.0"
-    hyperlinker "^1.0.0"
-    indent-string "^4.0.0"
-    is-wsl "^2.2.0"
-    js-yaml "^3.14.1"
-    natural-orderby "^2.0.3"
-    object-treeify "^1.1.33"
-    password-prompt "^1.1.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    supports-color "^8.1.1"
-    supports-hyperlinks "^2.2.0"
-    ts-node "^10.9.1"
-    tslib "^2.5.0"
-    widest-line "^3.1.0"
-    wordwrap "^1.0.0"
-    wrap-ansi "^7.0.0"
 
 "@oclif/core@2.8.6":
   version "2.8.6"
@@ -393,6 +359,40 @@
     object-treeify "^1.1.33"
     password-prompt "^1.1.2"
     semver "^7.3.7"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    ts-node "^10.9.1"
+    tslib "^2.5.0"
+    widest-line "^3.1.0"
+    wordwrap "^1.0.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/core@^2.15.0":
+  version "2.16.0"
+  resolved "https://registry.npmjs.org/@oclif/core/-/core-2.16.0.tgz"
+  integrity sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==
+  dependencies:
+    "@types/cli-progress" "^3.11.0"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.12.0"
+    debug "^4.3.4"
+    ejs "^3.1.8"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
@@ -651,7 +651,23 @@
     fast-url-parser "^1.1.3"
     tslib "^2.3.1"
 
-abort-controller@*, abort-controller@^3.0.0:
+JSONStream@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz"
+  integrity sha512-mn0KSip7N4e0UDPZHnqDsHECo5uGQrixQKnAskOM1BIB8hd7QKbd6il8IPRPudPHOeHiECoCFqhyMaRO9+nWyA==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
+abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -778,15 +794,6 @@ asn1js@^3.0.1, asn1js@^3.0.5:
     pvutils "^1.1.3"
     tslib "^2.4.0"
 
-assemblyscript@^0.19.20:
-  version "0.19.23"
-  resolved "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz"
-  integrity sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==
-  dependencies:
-    binaryen "102.0.0-nightly.20211028"
-    long "^5.2.0"
-    source-map-support "^0.5.20"
-
 assemblyscript@0.19.10:
   version "0.19.10"
   resolved "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.10.tgz"
@@ -795,7 +802,7 @@ assemblyscript@0.19.10:
     binaryen "101.0.0-nightly.20210723"
     long "^4.0.0"
 
-assemblyscript@0.19.23:
+assemblyscript@0.19.23, assemblyscript@^0.19.20:
   version "0.19.23"
   resolved "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz"
   integrity sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==
@@ -892,6 +899,11 @@ blob-to-it@^1.0.1:
   dependencies:
     browser-readablestream-to-it "^1.0.3"
 
+bn.js@4.11.6:
+  version "4.11.6"
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+  integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
+
 bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -901,11 +913,6 @@ bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
-
-bn.js@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
-  integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1044,6 +1051,14 @@ cborg@^1.5.4, cborg@^1.6.0:
   resolved "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz"
   integrity sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==
 
+chalk@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -1057,14 +1072,6 @@ chalk@^4, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -1157,17 +1164,17 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-colors@^1.1.2, colors@1.4.0:
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -1243,7 +1250,7 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.3, cross-spawn@7.0.3:
+cross-spawn@7.0.3, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1251,6 +1258,13 @@ cross-spawn@^7.0.3, cross-spawn@7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+debug@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^3.2.6:
   version "3.2.7"
@@ -1263,13 +1277,6 @@ debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.5"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.3.4:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -1337,8 +1344,8 @@ docker-modem@^1.0.8:
   resolved "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.9.tgz"
   integrity sha512-lVjqCSCIAUDZPAZIeyM125HXfNvOmYYInciphNrLrylUtKyW66meAjSPXWchKVzoIYZx69TPnAepVSSkeawoIw==
   dependencies:
-    debug "^3.2.6"
     JSONStream "1.3.2"
+    debug "^3.2.6"
     readable-stream "~1.0.26-4"
     split-ca "^1.0.0"
 
@@ -1351,17 +1358,17 @@ dockerode@2.5.8:
     docker-modem "^1.0.8"
     tar-fs "~1.16.3"
 
-ejs@^3.1.8:
-  version "3.1.10"
-  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz"
-  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
-  dependencies:
-    jake "^10.8.5"
-
 ejs@3.1.8:
   version "3.1.8"
   resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz"
   integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
+
+ejs@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
 
@@ -1371,19 +1378,6 @@ electron-fetch@^1.7.2:
   integrity sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==
   dependencies:
     encoding "^0.1.13"
-
-elliptic@^6.5.4:
-  version "6.5.5"
-  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz"
-  integrity sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
 
 elliptic@6.5.4:
   version "6.5.4"
@@ -1398,12 +1392,25 @@ elliptic@6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+elliptic@^6.5.4:
+  version "6.5.5"
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz"
+  integrity sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-encoding@^0.1.0, encoding@^0.1.13:
+encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -1460,15 +1467,15 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
 escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
@@ -1642,7 +1649,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^9.1.0, fs-extra@9.1.0:
+fs-extra@9.1.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -1720,6 +1727,16 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob@9.3.5:
+  version "9.3.5"
+  resolved "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
+
 glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
@@ -1731,16 +1748,6 @@ glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@9.3.5:
-  version "9.3.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz"
-  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    minimatch "^8.0.2"
-    minipass "^4.2.4"
-    path-scurry "^1.6.1"
 
 globby@^11.1.0:
   version "11.1.0"
@@ -1807,15 +1814,15 @@ graphql-import-node@^0.0.5:
   resolved "https://registry.npmjs.org/graphql-import-node/-/graphql-import-node-0.0.5.tgz"
   integrity sha512-OXbou9fqh9/Lm7vwXT0XoRN9J5+WCYKnbiTalgFDvkQERITRmcfncZs6aVABedd5B85yQU5EULS4a5pnbpuI0Q==
 
-graphql@*, graphql@^16.6.0:
-  version "16.8.1"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz"
-  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
-
 graphql@15.5.0:
   version "15.5.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+
+graphql@^16.6.0:
+  version "16.8.1"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1853,7 +1860,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7, hash.js@1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -1947,7 +1954,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@2:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2139,15 +2146,15 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2227,13 +2234,13 @@ jayson@4.0.0:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
-    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.4.5"
 
@@ -2247,7 +2254,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.14.1, js-yaml@3.14.1:
+js-yaml@3.14.1, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -2285,22 +2292,6 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
-
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
-JSONStream@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz"
-  integrity sha512-mn0KSip7N4e0UDPZHnqDsHECo5uGQrixQKnAskOM1BIB8hd7QKbd6il8IPRPudPHOeHiECoCFqhyMaRO9+nWyA==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 keccak@^3.0.0:
   version "3.0.4"
@@ -2533,15 +2524,15 @@ minipass@^4.2.4:
   resolved "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz"
   integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
-
 minipass@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -2563,15 +2554,15 @@ mkdirp@^1.0.3:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multiaddr-to-uri@^8.0.0:
   version "8.0.0"
@@ -2622,7 +2613,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@*, node-fetch@^2.6.8:
+node-fetch@^2.6.8:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -3006,12 +2997,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3035,11 +3021,6 @@ secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-semver@^7.3.7:
-  version "7.6.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz"
-  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
-
 semver@7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
@@ -3053,6 +3034,11 @@ semver@7.4.0:
   integrity sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.6.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
 
 set-function-length@^1.2.1:
   version "1.2.2"
@@ -3155,6 +3141,15 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -3173,15 +3168,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 strip-ansi@^5.2.0:
   version "5.2.0"
@@ -3383,11 +3369,6 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@>=2.7:
-  version "5.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz"
-  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
-
 uint8arrays@^3.0.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz"
@@ -3497,7 +3478,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which@^2.0.1, which@2.0.2:
+which@2.0.2, which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -3530,7 +3511,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^7.4.5:
+ws@^7.4.5:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
@@ -3545,7 +3526,7 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0, yaml@^1.10.2, yaml@1.10.2:
+yaml@1.10.2, yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
Introduces `TotalActiveOwedMDailySnapshot` to record daily snapshots of total owed M.

For more context, please check out [FS-150: totalActiveOwedM snapshots are too heavy](https://linear.app/mzero/issue/FS-150/totalactiveowedm-snapshots-are-too-heavy)

Preview subgraph deploy: https://subgraph.satsuma-prod.com/the-things-team--3422500/protocol-mainnet/version/v1.1.0-next.6/playground

## Demo

Here is a comparison of getting the latest total supply from the original `totalActiveOwedMs` query.

![Screenshot 2025-06-20 at 13 12 46](https://github.com/user-attachments/assets/197137a1-d74f-4309-950f-f9223e408050)
