### PR TITLE
Rate independent wM subgraph for spoke networks

### DIFF
--- a/stateful-l2-wrapped-m-token/deploy.sh
+++ b/stateful-l2-wrapped-m-token/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e  # stop if any command fails
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+if [ -z "$ALCHEMY_DEPLOY_KEY" ]; then
+  echo "Error: ALCHEMY_DEPLOY_KEY environment variable not set."
+  echo "Set it with: export ALCHEMY_DEPLOY_KEY=your_key_here"
+  exit 1
+fi
+
+VERSION="$1"
+
+echo "🧼 Cleaning up..."
+rm -rf ./build ./generated
+
+echo "👷‍♀️ Building subgraph..."
+yarn codegen
+yarn build
+
+echo "🚀 Deploying subgraph with version: $VERSION"
+yarn graph deploy wrapped-m-token-arbitrum \
+  --version-label "$VERSION" \
+  --node https://subgraphs.alchemy.com/api/subgraphs/deploy \
+  --deploy-key "$ALCHEMY_DEPLOY_KEY" \
+  --ipfs https://ipfs.satsuma.xyz
+
+echo "✅ Deployment complete"

--- a/stateful-l2-wrapped-m-token/package.json
+++ b/stateful-l2-wrapped-m-token/package.json
@@ -12,7 +12,8 @@
         "deploy-local": "graph deploy --node http://localhost:8020/ mzero/wrapped-m-token",
         "test": "graph test",
         "prettier": "prettier --write 'src/**/*.ts' 'scripts/**/*.js'",
-        "run:script": "ts-node ./scripts/periodic-yield.ts"
+        "test:periodic-yield": "ts-node ./scripts/periodic-yield.ts",
+        "test:total-accrued-yield": "ts-node ./scripts/total-accrued-yield.ts"
     },
     "dependencies": {},
     "devDependencies": {

--- a/stateful-l2-wrapped-m-token/package.json
+++ b/stateful-l2-wrapped-m-token/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "codegen": "graph codegen",
         "build": "graph build",
-        "deploy": "graph deploy --node https://api.thegraph.com/deploy/ mzero/wrapped-m-token",
+        "deploy": "./deploy.sh",
         "deploy:mainnet": "graph deploy wrapped-m-token-mainnet --network mainnet --version-label $(grep VERSION_LABEL .env | cut -d '=' -f2) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key $(grep DEPLOY_KEY .env | cut -d '=' -f2)",
         "create-local": "graph create --node http://localhost:8020/ mzero/wrapped-m-token",
         "remove-local": "graph remove --node http://localhost:8020/ mzero/wrapped-m-token",

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -40,10 +40,15 @@ type BalanceSnapshot implements HolderSnapshotEntity & BigIntSnapshotEntity & Sn
     value: BigInt!
 }
 
-type LastIndexTimestampSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity {
+# Earner's Balance and timestamp checkpoints to calculate principal and periodic yields
+# Deterministic checkpoints at the exact times the accrual state changes (claim/start/stop) for stateful accounting
+type CheckpointSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity {
     id: ID! @unique
     timestamp: Timestamp!
     account: Holder!
+    balance: BigInt!
+    blockNumber: BigInt!
+    logIndex: BigInt!
 }
 
 type IsEarningSnapshot implements HolderSnapshotEntity & BooleanSnapshotEntity & SnapshotEntity @entity {
@@ -79,8 +84,6 @@ type Holder @entity {
     address: String! @unique
     balance: BigInt!
     balanceSnapshots: [BalanceSnapshot!] @derivedFrom(field: "account")
-    lastIndexTimestamp: Timestamp!
-    lastIndexTimestampSnapshots: [LastIndexTimestampSnapshot!] @derivedFrom(field: "account")
     isEarning: Boolean!
     isEarningSnapshots: [IsEarningSnapshot!] @derivedFrom(field: "account")
     transfersTo: [Transfer!] @derivedFrom(field: "recipient")
@@ -94,6 +97,10 @@ type Holder @entity {
     sent: BigInt!
     sentSnapshots: [SentSnapshot!] @derivedFrom(field: "account")
     lastUpdate: Timestamp!
+    # deterministic checkpoints at the exact times the accrual state changes (claim/start/stop)
+    checkpointBalance: BigInt!
+    checkpointTimestamp: Timestamp!
+    CheckpointSnapshot: [CheckpointSnapshot!] @derivedFrom(field: "account")
 }
 
 type TotalNonEarningSupplySnapshot implements BigIntSnapshotEntity & SnapshotEntity @entity {

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -42,7 +42,7 @@ type BalanceSnapshot implements HolderSnapshotEntity & BigIntSnapshotEntity & Sn
 
 # Earner's Balance and timestamp checkpoints to calculate principal and periodic yields
 # Deterministic checkpoints at the exact times the accrual state changes (claim/start/stop) for stateful accounting
-type CheckpointSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity {
+type CheckpointSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity(immutable: true) {
     id: ID! @unique
     timestamp: Timestamp!
     account: Holder!

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -44,6 +44,7 @@ type BalanceSnapshot implements HolderSnapshotEntity & BigIntSnapshotEntity & Sn
 # Deterministic checkpoints at the exact times the accrual state changes (claim/start/stop) for stateful accounting
 type CheckpointSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity(immutable: true) {
     id: ID! @unique
+    kind: String! # (START|CLAIM|STOP)
     timestamp: Timestamp!
     account: Holder!
     balance: BigInt!
@@ -100,6 +101,7 @@ type Holder @entity {
     sentSnapshots: [SentSnapshot!] @derivedFrom(field: "account")
     lastUpdate: Timestamp!
     # deterministic checkpoints at the exact times the accrual state changes (claim/start/stop)
+    activeCheckpoint: CheckpointSnapshot # nullable
     checkpointSnapshots: [CheckpointSnapshot!] @derivedFrom(field: "account")
 }
 

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -100,8 +100,6 @@ type Holder @entity {
     sentSnapshots: [SentSnapshot!] @derivedFrom(field: "account")
     lastUpdate: Timestamp!
     # deterministic checkpoints at the exact times the accrual state changes (claim/start/stop)
-    checkpointBalance: BigInt!
-    checkpointTimestamp: Timestamp!
     checkpointSnapshots: [CheckpointSnapshot!] @derivedFrom(field: "account")
 }
 

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -102,7 +102,7 @@ type Holder @entity {
     # deterministic checkpoints at the exact times the accrual state changes (claim/start/stop)
     checkpointBalance: BigInt!
     checkpointTimestamp: Timestamp!
-    CheckpointSnapshot: [CheckpointSnapshot!] @derivedFrom(field: "account")
+    checkpointSnapshots: [CheckpointSnapshot!] @derivedFrom(field: "account")
 }
 
 type TotalNonEarningSupplySnapshot implements BigIntSnapshotEntity & SnapshotEntity @entity {

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -49,6 +49,8 @@ type CheckpointSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity
     balance: BigInt!
     blockNumber: BigInt!
     logIndex: BigInt!
+    mLatestIndex: BigInt!
+    mLatestUpdateTimestamp: Timestamp!
 }
 
 type IsEarningSnapshot implements HolderSnapshotEntity & BooleanSnapshotEntity & SnapshotEntity @entity {

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -111,12 +111,6 @@ type TotalNonEarningSupplySnapshot implements BigIntSnapshotEntity & SnapshotEnt
     value: BigInt!
 }
 
-type PrincipalOfTotalEarningSupplySnapshot implements BigIntSnapshotEntity & SnapshotEntity @entity {
-    id: ID! @unique
-    timestamp: Timestamp! @unique
-    value: BigInt!
-}
-
 type TotalEarningSupplySnapshot implements BigIntSnapshotEntity & SnapshotEntity @entity {
     id: ID! @unique
     timestamp: Timestamp! @unique

--- a/stateful-l2-wrapped-m-token/schema.graphql
+++ b/stateful-l2-wrapped-m-token/schema.graphql
@@ -40,11 +40,10 @@ type BalanceSnapshot implements HolderSnapshotEntity & BigIntSnapshotEntity & Sn
     value: BigInt!
 }
 
-type LastIndexSnapshot implements HolderSnapshotEntity & BigIntSnapshotEntity & SnapshotEntity @entity {
+type LastIndexTimestampSnapshot implements HolderSnapshotEntity & SnapshotEntity @entity {
     id: ID! @unique
     timestamp: Timestamp!
     account: Holder!
-    value: BigInt!
 }
 
 type IsEarningSnapshot implements HolderSnapshotEntity & BooleanSnapshotEntity & SnapshotEntity @entity {
@@ -80,8 +79,8 @@ type Holder @entity {
     address: String! @unique
     balance: BigInt!
     balanceSnapshots: [BalanceSnapshot!] @derivedFrom(field: "account")
-    lastIndex: BigInt!
-    lastIndexSnapshots: [LastIndexSnapshot!] @derivedFrom(field: "account")
+    lastIndexTimestamp: Timestamp!
+    lastIndexTimestampSnapshots: [LastIndexTimestampSnapshot!] @derivedFrom(field: "account")
     isEarning: Boolean!
     isEarningSnapshots: [IsEarningSnapshot!] @derivedFrom(field: "account")
     transfersTo: [Transfer!] @derivedFrom(field: "recipient")
@@ -162,8 +161,6 @@ type WrappedMToken @entity {
     holders: [Holder!]
     totalNonEarningSupply: BigInt!
     totalNonEarningSupplySnapshots: [TotalNonEarningSupplySnapshot!]
-    principalOfTotalEarningSupply: BigInt!
-    principalOfTotalEarningSupplySnapshots: [PrincipalOfTotalEarningSupplySnapshot!]
     totalEarningSupply: BigInt!
     totalEarningSupplySnapshots: [TotalEarningSupplySnapshot!]
     enableMIndex: BigInt!

--- a/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
+++ b/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
@@ -23,9 +23,7 @@ const historicalPeriods = parseInt(process.argv[4] || '0', 10);
 const period = BigInt(parseInt(process.argv[5] ?? '86400', 10)); // default 1 day in seconds
 
 if (!account || mostRecentPeriodEndTimestamp === 0n || Number.isNaN(historicalPeriods)) {
-    console.error(
-        'Usage: ts-node computeAccruedYields.ts <account> <mostRecentEndTs> <historicalPeriods> [periodSeconds]'
-    );
+    console.error('Usage: ts-node periodict-yield.ts <account> <mostRecentEndTs> <historicalPeriods> [periodSeconds]');
     process.exit(1);
 }
 

--- a/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
+++ b/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
@@ -105,15 +105,6 @@ function computePeriodicYields(
             checkpoint.timestamp
         );
 
-        // console.log({
-        //     timestamp,
-        //     latestIndex,
-        //     latestRate,
-        //     latestTimestamp,
-        //     checkpoint,
-        //     derivedIndex: holderLastCheckpointIndex,
-        // });
-
         const unclaimedYield =
             holderLastCheckpointIndex === 0n
                 ? 0n

--- a/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
+++ b/stateful-l2-wrapped-m-token/scripts/periodic-yield.ts
@@ -6,9 +6,9 @@ type Snapshot = { timestamp: bigint; value: bigint };
 type Snapshots = Snapshot[];
 type CheckpointSnapshots = {
     timestamp: bigint;
-    balance: bigint;
-    mLatestIndex: bigint;
-    mLatestUpdateTimestamp: bigint;
+    balance: string;
+    mLatestIndex: string;
+    mLatestUpdateTimestamp: string;
 }[];
 
 if (!process.env.API_SUBGRAPH || !process.env.API_M_ETHEREUM) {
@@ -101,9 +101,9 @@ function computePeriodicYields(
             throw new Error(`No checkpoint found at timestamp ${timestamp}`);
         }
         const holderLastCheckpointIndex = getCurrentIndex(
-            checkpoint.mLatestIndex,
+            BigInt(checkpoint.mLatestIndex),
             latestRate,
-            checkpoint.mLatestUpdateTimestamp,
+            BigInt(checkpoint.mLatestUpdateTimestamp),
             checkpoint.timestamp
         );
 

--- a/stateful-l2-wrapped-m-token/scripts/total-accrued-yield.ts
+++ b/stateful-l2-wrapped-m-token/scripts/total-accrued-yield.ts
@@ -140,15 +140,6 @@ async function fetchGraphQLFromUrl<T = any>(url: string, body: string): Promise<
 
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        // console.log({
-        //     timestamp,
-        //     latestIndex,
-        //     latestRate,
-        //     latestTimestamp,
-        //     checkpoint,
-        //     derivedIndex: holderLastCheckpointIndex,
-        // });
-
         const unclaimedYield =
             holderLastCheckpointIndex === 0n
                 ? 0n

--- a/stateful-l2-wrapped-m-token/scripts/total-accrued-yield.ts
+++ b/stateful-l2-wrapped-m-token/scripts/total-accrued-yield.ts
@@ -1,0 +1,176 @@
+import 'dotenv/config';
+import { getAccruedYield, getCurrentIndex } from './utils';
+
+// Types
+type Snapshot = { timestamp: bigint; value: bigint };
+type Snapshots = Snapshot[];
+
+if (!process.env.API_SUBGRAPH || !process.env.API_M_ETHEREUM) {
+    console.error('Missing API_SUBGRAPH or API_M_ETHEREUM environment variables');
+    process.exit(1);
+}
+
+// CLI args
+const account = (process.argv[2] || '').toLowerCase();
+
+if (!account) {
+    console.error('Usage: ts-node total-accrued-yield.ts <account>');
+    process.exit(1);
+}
+
+// -------- helpers --------
+
+function formatMicroDecimal(_x: bigint | string): string {
+    const x = typeof _x === 'string' ? BigInt(_x) : _x;
+    const whole = x / 1_000_000n;
+    const micro = (x % 1_000_000n).toString().padStart(6, '0');
+    return `${whole}.${micro}`;
+}
+
+// -------- GQL bodies (split: main vs. rates) --------
+function gqlBodyMain(account: string) {
+    return JSON.stringify({
+        query: `
+    {
+        holder(id: "holder-${account.toLocaleLowerCase()}") {
+            address
+            balance
+            isEarning
+            claimed
+            activeCheckpoint {
+                timestamp
+                balance
+                mLatestIndex
+                mLatestUpdateTimestamp
+            }
+        }
+        latestIndexSnapshots(orderBy: timestamp, orderDirection: desc, first: 1) {
+            timestamp
+            value
+        }
+    }`,
+    });
+}
+
+function gqlBodyRates() {
+    return JSON.stringify({
+        query: `
+      {
+        latestRateSnapshots(orderBy: timestamp, orderDirection: desc, first: 1) {
+          timestamp
+          value
+        }
+      }
+    `,
+    });
+}
+
+// -------- Fetch helpers --------
+async function fetchGraphQLFromUrl<T = any>(url: string, body: string): Promise<T> {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'user-agent': 'Node' },
+        body,
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`GraphQL error ${res.status}: ${text}`);
+    }
+    const text = await res.text();
+    return JSON.parse(text, (k, v) => (k === 'timestamp' || k === 'value' ? BigInt(v) : v)).data as T;
+}
+
+// -------- Run --------
+(async function main() {
+    try {
+        // 1) Fetch main payload (no rates)
+        const main = await fetchGraphQLFromUrl<{
+            holder: {
+                address: string;
+                balance: string;
+                isEarning: boolean;
+                claimed: bigint;
+                activeCheckpoint: {
+                    timestamp: bigint;
+                    balance: string;
+                    mLatestIndex: string;
+                    mLatestUpdateTimestamp: string;
+                };
+            };
+            latestIndexSnapshots: Snapshots;
+        }>(process.env.API_SUBGRAPH!, gqlBodyMain(account));
+
+        // 2) Fetch rates from a different endpoint
+        const rateSnapshots = await fetchGraphQLFromUrl<{ latestRateSnapshots: Snapshots }>(
+            process.env.API_M_ETHEREUM!,
+            gqlBodyRates()
+        );
+
+        const latestRate = rateSnapshots.latestRateSnapshots[0]?.value;
+
+        if (!latestRate || latestRate === 0n) {
+            throw new Error(`No rate data available`);
+        }
+
+        const indexData = main.latestIndexSnapshots[0];
+        if (!indexData) {
+            throw new Error(`No index data available`);
+        }
+        const { value: latestIndex, timestamp: latestTimestamp } = indexData;
+
+        const holder = main.holder;
+        if (!holder) {
+            throw new Error(`No holder data for account ${account}`);
+        }
+
+        if (holder.isEarning === false || !holder.activeCheckpoint) {
+            console.log(
+                `✨ Account ${account} is not earning yield. Total claimed yield: ${formatMicroDecimal(holder.claimed)}`
+            );
+
+            process.exit(0);
+        }
+
+        const holderLastCheckpointIndex = getCurrentIndex(
+            BigInt(holder.activeCheckpoint.mLatestIndex),
+            latestRate,
+            BigInt(holder.activeCheckpoint.mLatestUpdateTimestamp),
+            holder.activeCheckpoint.timestamp
+        );
+
+        const now = BigInt(Math.floor(Date.now() / 1000));
+
+        // console.log({
+        //     timestamp,
+        //     latestIndex,
+        //     latestRate,
+        //     latestTimestamp,
+        //     checkpoint,
+        //     derivedIndex: holderLastCheckpointIndex,
+        // });
+
+        const unclaimedYield =
+            holderLastCheckpointIndex === 0n
+                ? 0n
+                : getAccruedYield(
+                      BigInt(holder.balance),
+                      holderLastCheckpointIndex,
+                      latestIndex,
+                      latestRate,
+                      latestTimestamp,
+                      now
+                  );
+
+        const claimedYield = BigInt(holder.claimed);
+        const earnedYield = claimedYield + unclaimedYield;
+
+        console.log(`✨ Account ${account}`);
+        console.log(`   - Earned yield: ${formatMicroDecimal(earnedYield)}`);
+        console.log(`   - Claimed yield: ${formatMicroDecimal(claimedYield)}`);
+        console.log(`   - Unclaimed yield: ${formatMicroDecimal(unclaimedYield)}`);
+        console.log(`   - Current balance: ${formatMicroDecimal(holder.balance)}`);
+    } catch (err: any) {
+        console.error(err?.message ?? err);
+        process.exit(1);
+    }
+})();

--- a/stateful-l2-wrapped-m-token/scripts/utils.ts
+++ b/stateful-l2-wrapped-m-token/scripts/utils.ts
@@ -28,7 +28,7 @@ export function getAccruedYield(
     return balanceWithYield <= balance ? 0n : balanceWithYield - balance;
 }
 
-function getCurrentIndex(
+export function getCurrentIndex(
     latestIndex: bigint,
     latestRate: bigint,
     latestUpdateTimestamp: bigint,

--- a/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
+++ b/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
@@ -321,7 +321,7 @@ function updateBalanceSnapshot(holder: Holder, timestamp: Timestamp, value: BigI
 }
 
 function updateCheckpointSnapshot(
-    kind: 'START' | 'STOP' | 'CLAIM',
+    kind: string, // 'START' | 'STOP' | 'CLAIM'
     holder: Holder,
     timestamp: Timestamp,
     blockNumber: BigInt,

--- a/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
+++ b/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
@@ -89,7 +89,13 @@ export function handleStartedEarning(event: StartedEarningEvent): void {
     const timestamp = event.block.timestamp.toI32();
 
     _startEarning(wrappedMToken, account, timestamp);
-    updateCheckpointSnapshot(account, timestamp, event.block.number, event.logIndex);
+    updateCheckpointSnapshot(
+        account,
+        timestamp,
+        event.block.number,
+        event.logIndex,
+        event.transaction.hash.toHexString()
+    );
 
     wrappedMToken.lastUpdate = timestamp;
     wrappedMToken.save();
@@ -104,7 +110,13 @@ export function handleStoppedEarning(event: StoppedEarningEvent): void {
     const timestamp = event.block.timestamp.toI32();
 
     _stopEarning(wrappedMToken, account, timestamp);
-    updateCheckpointSnapshot(account, timestamp, event.block.number, event.logIndex);
+    updateCheckpointSnapshot(
+        account,
+        timestamp,
+        event.block.number,
+        event.logIndex,
+        event.transaction.hash.toHexString()
+    );
 
     wrappedMToken.lastUpdate = timestamp;
     wrappedMToken.save();
@@ -167,7 +179,13 @@ export function handleClaimed(event: ClaimedEvent): void {
     const timestamp = event.block.timestamp.toI32();
 
     _claim(wrappedMToken, account, event.params.amount, timestamp);
-    updateCheckpointSnapshot(account, timestamp, event.block.number, event.logIndex);
+    updateCheckpointSnapshot(
+        account,
+        timestamp,
+        event.block.number,
+        event.logIndex,
+        event.transaction.hash.toHexString()
+    );
 
     account.lastUpdate = timestamp;
     account.save();
@@ -300,8 +318,14 @@ function updateBalanceSnapshot(holder: Holder, timestamp: Timestamp, value: BigI
     snapshot.save();
 }
 
-function updateCheckpointSnapshot(holder: Holder, timestamp: Timestamp, blockNumber: BigInt, logIndex: BigInt): void {
-    const id = `checkpointSnapshot-${holder.address}-${timestamp.toString()}`;
+function updateCheckpointSnapshot(
+    holder: Holder,
+    timestamp: Timestamp,
+    blockNumber: BigInt,
+    logIndex: BigInt,
+    txHash: string
+): void {
+    const id = `checkpoint-${holder.address}-${txHash}-${logIndex.toString()}`;
     const mToken = getMToken();
 
     let snapshot = CheckpointSnapshot.load(id);

--- a/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
+++ b/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
@@ -14,7 +14,6 @@ import {
     LatestUpdateTimestampSnapshot,
     Migration,
     MToken,
-    PrincipalOfTotalEarningSupplySnapshot,
     ReceivedSnapshot,
     SentSnapshot,
     TotalBurnedSnapshot,

--- a/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
+++ b/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
@@ -302,6 +302,7 @@ function updateBalanceSnapshot(holder: Holder, timestamp: Timestamp, value: BigI
 
 function updateCheckpointSnapshot(holder: Holder, timestamp: Timestamp, blockNumber: BigInt, logIndex: BigInt): void {
     const id = `checkpointSnapshot-${holder.address}-${timestamp.toString()}`;
+    const mToken = getMToken();
 
     let snapshot = CheckpointSnapshot.load(id);
 
@@ -314,6 +315,8 @@ function updateCheckpointSnapshot(holder: Holder, timestamp: Timestamp, blockNum
     snapshot.balance = holder.balance;
     snapshot.blockNumber = blockNumber;
     snapshot.logIndex = logIndex;
+    snapshot.mLatestIndex = mToken.latestIndex;
+    snapshot.mLatestUpdateTimestamp = mToken.latestUpdateTimestamp;
 
     snapshot.save();
 }
@@ -393,22 +396,6 @@ function updateTotalNonEarningSupplySnapshot(timestamp: Timestamp, value: BigInt
 
     if (!snapshot) {
         snapshot = new TotalNonEarningSupplySnapshot(id);
-
-        snapshot.timestamp = timestamp;
-    }
-
-    snapshot.value = value;
-
-    snapshot.save();
-}
-
-function updatePrincipalOfTotalEarningSupplySnapshot(timestamp: Timestamp, value: BigInt): void {
-    const id = `principalOfTotalEarningSupply-${timestamp.toString()}`;
-
-    let snapshot = PrincipalOfTotalEarningSupplySnapshot.load(id);
-
-    if (!snapshot) {
-        snapshot = new PrincipalOfTotalEarningSupplySnapshot(id);
 
         snapshot.timestamp = timestamp;
     }

--- a/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
+++ b/stateful-l2-wrapped-m-token/src/wm-mappings-l2.ts
@@ -274,8 +274,6 @@ function getHolder(address: Address): Holder {
 
     holder.address = address.toHexString();
     holder.balance = BigInt.fromI32(0);
-    holder.checkpointBalance = BigInt.fromI32(0);
-    holder.checkpointTimestamp = 0;
     holder.isEarning = false;
     holder.claimed = BigInt.fromI32(0);
     holder.received = BigInt.fromI32(0);
@@ -625,8 +623,6 @@ function _mint(wrappedMToken: WrappedMToken, recipient: Holder, amount: BigInt, 
 
 function _startEarning(wrappedMToken: WrappedMToken, account: Holder, timestamp: Timestamp): void {
     account.isEarning = true;
-    account.checkpointTimestamp = timestamp;
-    account.checkpointBalance = account.balance;
 
     updateIsEarningSnapshot(account, timestamp, account.isEarning);
 
@@ -641,8 +637,6 @@ function _startEarning(wrappedMToken: WrappedMToken, account: Holder, timestamp:
 
 function _stopEarning(wrappedMToken: WrappedMToken, account: Holder, timestamp: Timestamp): void {
     account.isEarning = false;
-    account.checkpointTimestamp = 0;
-    account.checkpointBalance = account.balance;
 
     updateIsEarningSnapshot(account, timestamp, account.isEarning);
 
@@ -657,8 +651,6 @@ function _stopEarning(wrappedMToken: WrappedMToken, account: Holder, timestamp: 
 
 function _claim(wrappedMToken: WrappedMToken, account: Holder, amount: BigInt, timestamp: Timestamp): void {
     account.claimed = account.claimed.plus(amount);
-    account.checkpointTimestamp = timestamp;
-    account.checkpointBalance = account.balance;
 
     updateClaimedSnapshot(account, timestamp, account.claimed);
 


### PR DESCRIPTION
Make the $M Wrapped subgraph for spoke networks rate independent. 

Some context: Our spoke networks don't emit rate information on `IndexUpdate`. Previously we used a hardcoded rate to compute a per-account scalar `holder.lastIndex` and to settle accrual. That was fragile and cross-chain incorrect.

This changes remove the rate math and store deterministic checkpoints for client to calculate that accrual state.

**What this does**
* Remove rate math from the subgraph. We no longer derive currentIndex(t) in mappings.
* Introduce deterministic checkpoints (written only on start/claim/stop) to anchor accrual off-chain:
    * `CheckpointSnapshot { account, timestamp, balance, mLatestIndex, mLatestUpdateTimestamp }`
    * `holder.activeCheckpoint`: pointer to the latest earning checkpoint (cleared on stop).
* Subgraph becomes rate-agnostic and deterministic across reindexes.

**Schema breaking changes**
* Drop `holder.lastIndex`, `mToken.principalOfTotalEarningSupply` and `PrincipalOfTotalEarningSupplySnapshots`.
* Add `holder.activeCheckpoint` `CheckpointSnapshot`
* Update `script/periodic-yield.ts` 
* Add deploy script

Preview subgraph api playground:  https://subgraph.satsuma-prod.com/the-things-team--3422500/wrapped-m-token-arbitrum/version/0.2.0-next.4/playground

**Todo**
* [x] Add script example for total accrued yield

<details>
<summary>Tests</summary>

Results running `script/periodic-yield.ts`
<img width="1244" height="993" alt="Screenshot 2025-08-22 at 00 13 52" src="https://github.com/user-attachments/assets/ae360785-2f37-4e27-b5e1-0db2b7cd63ff" />


Notice how total accrued yield is close (1) to what we currently display and most importantly, the former `holder.lastIndex`  is derived precisely from Checkpoints data when compared to the second screenshot below:

(1): total accrued yield won't match because in production there is a block height skew. I.e. the block heights aren't exactly the same between production and what I get on local machine.



<img width="1169" height="750" alt="Screenshot 2025-08-22 at 00 14 55" src="https://github.com/user-attachments/assets/36fbe4c6-b5a2-4dec-8309-247d4e383ab1" />

<img width="1093" height="879" alt="Screenshot 2025-08-22 at 00 14 31" src="https://github.com/user-attachments/assets/5bf75f8b-211e-4a2b-b484-2549a6f78896" />




</details>
